### PR TITLE
Removing tags pattern since we can't use this with check-jsonschema.

### DIFF
--- a/src/model/schema/schema.json
+++ b/src/model/schema/schema.json
@@ -912,15 +912,13 @@
                         "description": "One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.",
                         "type": "string",
                         "maxLength": 128,
-                        "minLength": 1,
-                        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+                        "minLength": 1
                     },
                     "value": {
                         "description": "The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).",
                         "type": "string",
                         "maxLength": 256,
-                        "minLength": 0,
-                        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+                        "minLength": 0
                     }
                 },
                 "additionalProperties": false


### PR DESCRIPTION
I am wanting to add validating AWS ECS task definitions using the [schema.json](https://raw.githubusercontent.com/awslabs/amazon-ecs-intellisense-schema/mainline/src/model/schema/schema.json) as part of [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema). Which then can checked via a `pre-commit` hook.

But the probably I am having is show below and it centers around `tags` `pattern`.

I have tested intellisense with VS Code and my [schema.json](https://raw.githubusercontent.com/djgoku/amazon-ecs-intellisense-schema/chore/remove-tag-pattern/src/model/schema/schema.json) which doesn't have `tags` `pattern` and it still works great.

For context here is the errors I see without and with `tags` `pattern`. Here is a [valid AWS ECS task definition](https://github.com/djgoku/check-jsonschema/blob/feature/add-vendor-aws-ecs-task-definition/tests/example-files/hooks/positive/aws-ecs-task-definition/ecs-anywhere-runtask-task-definition.json) and here is the [invalid AWS ECS task definition](https://github.com/djgoku/check-jsonschema/blob/feature/add-vendor-aws-ecs-task-definition/tests/example-files/hooks/negative/aws-ecs-task-definition/aws-ecs-task-definition.json).

Without `tags` `pattern` happy path:
```
$ check-jsonschema --schemafile https://raw.githubusercontent.com/djgoku/amazon-ecs-intellisense-schema/chore/remove-tag-pattern/src/model/schema/schema.json tests/example-files/hooks/positive/aws-ecs-task-definition/ecs-anywhere-runtask-task-definition.json 
ok -- validation done
```

Without `tags` `pattern` fail path:
```
$ check-jsonschema --schemafile https://raw.githubusercontent.com/djgoku/amazon-ecs-intellisense-schema/chore/remove-tag-pattern/src/model/schema/schema.json tests/example-files/hooks/negative/aws-ecs-task-definition/aws-ecs-task-definition.json 
Schema validation errors were encountered.
  tests/example-files/hooks/negative/aws-ecs-task-definition/aws-ecs-task-definition.json::$: 'family' is a required property
  tests/example-files/hooks/negative/aws-ecs-task-definition/aws-ecs-task-definition.json::$: 'containerDefinitions' is a required property
```

With current `tags` `pattern` happy path:
```
$ check-jsonschema --schemafile https://raw.githubusercontent.com/awslabs/amazon-ecs-intellisense-schema/mainline/src/model/schema/schema.json tests/example-files/hooks/positive/aws-ecs-task-definition/ecs-anywhere-runtask-task-definition.json 
Error: schemafile was not valid: {'type': 'object', 'properties': {'key': {'description': 'One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.', 'type': 'string', 'maxLength': 128, 'minLength': 1, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}, 'value': {'description': 'The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).', 'type': 'string', 'maxLength': 256, 'minLength': 0, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}}, 'additionalProperties': False} is not valid under any of the given schemas

Failed validating 'anyOf' in metaschema['properties']['properties']['additionalProperties']['properties']['items']:
    {'anyOf': [{'$ref': '#'}, {'$ref': '#/definitions/schemaArray'}],
     'default': True}

On schema['properties']['tags']['items']:
    {'additionalProperties': False,
     'properties': {'key': {'description': 'One part of a key-value pair '
                                           'that make up a tag. A key is a '
                                           'general label that acts like a '
                                           'category for more specific tag '
                                           'values.',
                            'maxLength': 128,
                            'minLength': 1,
                            'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                            'type': 'string'},
                    'value': {'description': 'The optional part of a '
                                             'key-value pair that make up '
                                             'a tag. A value acts as a '
                                             'descriptor within a tag '
                                             'category (key).',
                              'maxLength': 256,
                              'minLength': 0,
                              'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                              'type': 'string'}},
     'type': 'object'}

SchemaError: {'type': 'object', 'properties': {'key': {'description': 'One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.', 'type': 'string', 'maxLength': 128, 'minLength': 1, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}, 'value': {'description': 'The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).', 'type': 'string', 'maxLength': 256, 'minLength': 0, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}}, 'additionalProperties': False} is not valid under any of the given schemas

Failed validating 'anyOf' in metaschema['properties']['properties']['additionalProperties']['properties']['items']:
    {'anyOf': [{'$ref': '#'}, {'$ref': '#/definitions/schemaArray'}],
     'default': True}

On schema['properties']['tags']['items']:
    {'additionalProperties': False,
     'properties': {'key': {'description': 'One part of a key-value pair '
                                           'that make up a tag. A key is a '
                                           'general label that acts like a '
                                           'category for more specific tag '
                                           'values.',
                            'maxLength': 128,
                            'minLength': 1,
                            'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                            'type': 'string'},
                    'value': {'description': 'The optional part of a '
                                             'key-value pair that make up '
                                             'a tag. A value acts as a '
                                             'descriptor within a tag '
                                             'category (key).',
                              'maxLength': 256,
                              'minLength': 0,
                              'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                              'type': 'string'}},
     'type': 'object'}
  in "/Users/dj_goku/dev/github/djgoku/check-jsonschema/.venv/lib/python3.10/site-packages/check_jsonschema/checker.py", line 53
  >>> return self._schema_loader.get_validator(
```

With current `tags` `pattern` fail path:
```
$ check-jsonschema --schemafile https://raw.githubusercontent.com/awslabs/amazon-ecs-intellisense-schema/mainline/src/model/schema/schema.json tests/example-files/hooks/negative/aws-ecs-task-definition/aws-ecs-task-definition.json 
Error: schemafile was not valid: {'type': 'object', 'properties': {'key': {'description': 'One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.', 'type': 'string', 'maxLength': 128, 'minLength': 1, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}, 'value': {'description': 'The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).', 'type': 'string', 'maxLength': 256, 'minLength': 0, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}}, 'additionalProperties': False} is not valid under any of the given schemas

Failed validating 'anyOf' in metaschema['properties']['properties']['additionalProperties']['properties']['items']:
    {'anyOf': [{'$ref': '#'}, {'$ref': '#/definitions/schemaArray'}],
     'default': True}

On schema['properties']['tags']['items']:
    {'additionalProperties': False,
     'properties': {'key': {'description': 'One part of a key-value pair '
                                           'that make up a tag. A key is a '
                                           'general label that acts like a '
                                           'category for more specific tag '
                                           'values.',
                            'maxLength': 128,
                            'minLength': 1,
                            'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                            'type': 'string'},
                    'value': {'description': 'The optional part of a '
                                             'key-value pair that make up '
                                             'a tag. A value acts as a '
                                             'descriptor within a tag '
                                             'category (key).',
                              'maxLength': 256,
                              'minLength': 0,
                              'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                              'type': 'string'}},
     'type': 'object'}

SchemaError: {'type': 'object', 'properties': {'key': {'description': 'One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.', 'type': 'string', 'maxLength': 128, 'minLength': 1, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}, 'value': {'description': 'The optional part of a key-value pair that make up a tag. A value acts as a descriptor within a tag category (key).', 'type': 'string', 'maxLength': 256, 'minLength': 0, 'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$'}}, 'additionalProperties': False} is not valid under any of the given schemas

Failed validating 'anyOf' in metaschema['properties']['properties']['additionalProperties']['properties']['items']:
    {'anyOf': [{'$ref': '#'}, {'$ref': '#/definitions/schemaArray'}],
     'default': True}

On schema['properties']['tags']['items']:
    {'additionalProperties': False,
     'properties': {'key': {'description': 'One part of a key-value pair '
                                           'that make up a tag. A key is a '
                                           'general label that acts like a '
                                           'category for more specific tag '
                                           'values.',
                            'maxLength': 128,
                            'minLength': 1,
                            'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                            'type': 'string'},
                    'value': {'description': 'The optional part of a '
                                             'key-value pair that make up '
                                             'a tag. A value acts as a '
                                             'descriptor within a tag '
                                             'category (key).',
                              'maxLength': 256,
                              'minLength': 0,
                              'pattern': '^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$',
                              'type': 'string'}},
     'type': 'object'}
  in "/Users/dj_goku/dev/github/djgoku/check-jsonschema/.venv/lib/python3.10/site-packages/check_jsonschema/checker.py", line 53
  >>> return self._schema_loader.get_validator(
```
